### PR TITLE
Easly switch between production and local env in VSC HTTP script

### DIFF
--- a/scripts/vsc-http/.vscode/settings.json
+++ b/scripts/vsc-http/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "rest-client.environmentVariables": {
+        "local": {
+            "host": "https://localhost:49153"
+        },
+        "production": {
+            "host": "https://blef.azurewebsites.net"
+        } 
+    }
+}

--- a/scripts/vsc-http/Games.http
+++ b/scripts/vsc-http/Games.http
@@ -1,4 +1,3 @@
-@host = https://localhost:49153 
 @module = games-module
 @api = {{host}}/{{module}}
 


### PR DESCRIPTION
Currently, active environment's name is displayed at the right bottom of Visual Studio Code, when you click it, you can switch environment in the pop-up list. And you can also switch environment using shortcut Ctrl+Alt+E(Cmd+Alt+E for macOS), or press F1 and then select/type Rest Client: Switch Environment.

 For more details, how to do it, see that: https://marketplace.visualstudio.com/items?itemName=humao.rest-client#environment